### PR TITLE
Fix dimnames error resulting from early termination when VTR is reached.

### DIFF
--- a/R/DEoptim.R
+++ b/R/DEoptim.R
@@ -130,7 +130,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...) {
   ## member
   names(lower) <- names(upper) <- nam
   #bestmemit <- matrix(outC$bestmemit, nrow = iter, ncol = ctrl$npar, byrow = TRUE)
-  bestmemit <- outC$bestmemit
+  bestmemit <- outC$bestmemit[seq_len(iter), ]
 
   dimnames(bestmemit) <- list(1:iter, nam)
   bestvalit <- as.numeric(outC$bestvalit[1:iter])

--- a/R/DEoptim.R
+++ b/R/DEoptim.R
@@ -130,7 +130,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...) {
   ## member
   names(lower) <- names(upper) <- nam
   #bestmemit <- matrix(outC$bestmemit, nrow = iter, ncol = ctrl$npar, byrow = TRUE)
-  bestmemit <- outC$bestmemit[seq_len(iter), ]
+  bestmemit <- outC$bestmemit[seq_len(iter), , drop = FALSE]
 
   dimnames(bestmemit) <- list(1:iter, nam)
   bestvalit <- as.numeric(outC$bestvalit[1:iter])

--- a/man/DEoptim.control.Rd
+++ b/man/DEoptim.control.Rd
@@ -44,7 +44,7 @@ DEoptim.control(VTR = -Inf, strategy = 2, bs = FALSE, NP = 50,
     \item{itermax}{the maximum iteration (population generation) allowed.
       Default is \code{200}.}
     \item{CR}{crossover probability from interval [0,1]. Default
-      to \code{0.9}.}
+      to \code{0.5}.}
     \item{F}{step-size from interval [0,2]. Default to \code{0.8}.}
     \item{trace}{Printing of progress occurs? Default to \code{TRUE}. If
       numeric, progress will be printed every \code{trace} iterations.}


### PR DESCRIPTION
I was getting 
```
Error in dimnames(bestmemit) <- list(1:iter, nam) : 
  length of 'dimnames' [1] not equal to array extent
```
presumably because the `VTR` I had set was reached, which caused `DEoptim_impl()` to return a matrix with more rows than `iter`, which subsequently caused the error above when dimnames was called with the too short vector `1:iter`.