### PR TITLE
Allow extra parameters to be passed on to XPtr objective function

### DIFF
--- a/R/DEoptim.R
+++ b/R/DEoptim.R
@@ -77,7 +77,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...) {
   else
     nam <- paste("par", 1:length(lower), sep = "")
 
-  env <- new.env()
+  env <- list2env(list(...))
 
   ctrl <- do.call(DEoptim.control, as.list(control))
   ctrl$npar <- length(lower)

--- a/src/devol.cpp
+++ b/src/devol.cpp
@@ -27,11 +27,11 @@ void devol(double VTR, double f_weight, double f_cross, int i_bs_flag,
            double d_reltol, int i_steptol) { 
 
     //ProfilerStart("/tmp/RcppDE.prof");
-    Rcpp::DE::EvalBase *ev = NULL;              // pointer to abstract base class
-    if (TYPEOF(fcall) == EXTPTRSXP) {           // non-standard mode: we are being passed an external pointer
-        ev = new Rcpp::DE::EvalCompiled(fcall); // so assign a pointer using external pointer in fcall SEXP
-    } else {                                    // standard mode: env_ is an env, fcall_ is a function 
-        ev = new Rcpp::DE::EvalStandard(fcall, rho);    // so assign R function and environment
+    Rcpp::DE::EvalBase *ev = NULL;                   // pointer to abstract base class
+    if (TYPEOF(fcall) == EXTPTRSXP) {                // non-standard mode: we are being passed an external pointer
+        ev = new Rcpp::DE::EvalCompiled(fcall, rho); // so assign a pointer using external pointer in fcall SEXP
+    } else {                                         // standard mode: env_ is an env, fcall_ is a function 
+        ev = new Rcpp::DE::EvalStandard(fcall, rho); // so assign R function and environment
     }
     const int urn_depth = 5;                    // 4 + one index to avoid 
     Rcpp::NumericVector par(i_D);               // initialize parameter vector to pass to evaluate function 
@@ -285,8 +285,8 @@ SEXP putFunPtrInXPtr(SEXP funname) { 			// needed for tests/
     if (fstr == "genrose")
         return(Rcpp::XPtr<Rcpp::DE::funcPtr>(new Rcpp::DE::funcPtr(&Rcpp::DE::genrose)));
     else if (fstr == "wild")
-        return(Rcpp::XPtr<Rcpp::DE::funcPtr>(new Rcpp::DE::funcPtr(&Rcpp::DE::wild)));
+        return(Rcpp::XPtr<Rcpp::DE::funcPtrTest>(new Rcpp::DE::funcPtrTest(&Rcpp::DE::wild)));
     else
-        return(Rcpp::XPtr<Rcpp::DE::funcPtr>(new Rcpp::DE::funcPtr(&Rcpp::DE::rastrigin)));
+        return(Rcpp::XPtr<Rcpp::DE::funcPtrTest>(new Rcpp::DE::funcPtrTest(&Rcpp::DE::rastrigin)));
 }
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -4,6 +4,9 @@
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel <edd@debian.org>
 //
 // DEoptim is Copyright (C) 2009 David Ardia and Katharine Mullen
+//
+// Adjustments to allow environments for compiled functions were adopted from
+// Rmalschains 0.2-3
 
 #ifndef Rcpp_DE_evaluate_h_
 #define Rcpp_DE_evaluate_h_
@@ -81,14 +84,14 @@ namespace Rcpp {
         
         class EvalCompiled : public EvalBase {
         public:
-            EvalCompiled(Rcpp::XPtr<funcPtr> xptr, SEXP __env) {
+            EvalCompiled(Rcpp::XPtr<funcPtr> xptr, SEXP env_) {
                 funptr = *(xptr);
-                env = __env;
+                env = env_;
             };
-            EvalCompiled(SEXP xps, SEXP __env) {
+            EvalCompiled(SEXP xps, SEXP env_) {
                 Rcpp::XPtr<funcPtr> xptr(xps);
                 funptr = *(xptr);
-                env = __env;
+                env = env_;
             };
             double eval(SEXP par) {
                 neval++;

--- a/tests/compTest.R
+++ b/tests/compTest.R
@@ -7,11 +7,10 @@ Rastrigin <- function(x) {
     sum(x+2 - 10 * cos(2*pi*x)) + 20
 }
 
-Genrose <- function(x) { 	## One generalization of the Rosenbrock banana valley function (n parameters)
+Genrose <- function(x, a = 1, b = 100) { 	## One generalization of the Rosenbrock banana valley function (n parameters)
     n <- length(x)
-    1.0 + sum (100 * (x[-n]^2 - x[-1])^2 + (x[-1] - 1)^2)
+    1.0 + sum (b * (x[-n]^2 - x[-1])^2 + (x[-1] - a)^2)
 }
-
 
 maxIt <- 25         		# not excessive but so that we get some run-time on simple problems
 
@@ -20,10 +19,12 @@ suppressMessages({
     library(RcppDE) 		# the contender
 })
 
-basicDE <- function(n, maxIt, fun) DEoptim::DEoptim(fn=fun, lower=rep(-25, n), upper=rep(25, n),
-                                                    control=list(NP=10*n, itermax=maxIt, trace=FALSE))#, bs=TRUE))
-cppDE <- function(n, maxIt, fun) RcppDE::DEoptim(fn=fun, lower=rep(-25, n), upper=rep(25, n),
-                                                 control=list(NP=10*n, itermax=maxIt, trace=FALSE))#, bs=TRUE))
+basicDE <- function(n, maxIt, fun, ...) DEoptim::DEoptim(fn=fun, lower=rep(-25, n), upper=rep(25, n),
+                                                         control=list(NP=10*n, itermax=maxIt, trace=FALSE),
+                                                         ...)#, bs=TRUE))
+cppDE <- function(n, maxIt, fun, ...) RcppDE::DEoptim(fn=fun, lower=rep(-25, n), upper=rep(25, n),
+                                                      control=list(NP=10*n, itermax=maxIt, trace=FALSE),
+                                                      ...)#, bs=TRUE))
 
 set.seed(42)
 valBasic <- basicDE(5, maxIt, function(...) Rastrigin(...))
@@ -31,21 +32,21 @@ set.seed(42)
 valCpp <- cppDE(5, maxIt, function(...) Rastrigin(...))
 #stopifnot( all.equal(valBasic, valCpp) )
 
-runPair <- function(n, maxIt, fun, funname) {
+runPair <- function(n, maxIt, fun, funname, ...) {
     gc()
     set.seed(42)
-    bt <- system.time(invisible(ores <- basicDE(n, maxIt, fun)))[3]
+    bt <- system.time(invisible(ores <- basicDE(n, maxIt, fun, ...)))[3]
 
     gc()
     set.seed(42)
     xptr <- RcppDE:::putFunPtrInXPtr(funname)
-    ct <- system.time(invisible(cres <- cppDE(n, maxIt, xptr)))[3]
+    ct <- system.time(invisible(cres <- cppDE(n, maxIt, xptr, ...)))[3]
 
     #stopifnot(all.equal(ores, cres))
 
     gc()
     set.seed(42)
-    rt <- system.time(invisible(rres <- cppDE(n, maxIt, fun)))[3]
+    rt <- system.time(invisible(rres <- cppDE(n, maxIt, fun, ...)))[3]
 
     #stopifnot(all.equal(ores, rres))
 
@@ -58,7 +59,7 @@ reps <- c(5, 10, 20, 50)
 
 res <- rbind(do.call(rbind, lapply(reps, runPair, maxIt, function(...) Rastrigin(...), "rastrigin")),
              do.call(rbind, lapply(reps, runPair, maxIt, function(...) Wild(...), "wild")),
-             do.call(rbind, lapply(reps, runPair, maxIt, function(...) Genrose(...), "genrose"))
+             do.call(rbind, lapply(reps, runPair, maxIt, function(...) Genrose(...), "genrose", a = 1, b = 100))
              )
 res <- rbind(res, colMeans(res))
 


### PR DESCRIPTION
This pull request adds the option of passing additional arguments through ... and via Rcpp::DE::EvalCompiled to compiled objective functions. This was inspired by the Rmalschains package, from which some of the code was adopted. I am not completely confident that list2env(list(...)) is the best way to handle this but it seems more streamlined than using a separate environment argument (as Rmalschains does).

I also adjusted one of the tests to invoke and test this functionality and had to add a typedef, funcPtrTest, to make the tests work as before.

If I'm not mistaken, this shouldn't mean any user-visible differences.