### PR TITLE
suspend RNG synchronization (fixes #14)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2018-06-07  Kevin Ushey  <kevinushey@gmail.com>
 
 	* src/deoptim.cpp: disable RNG synchronization with dev. Rcpp
+	* tests/rosenbrock.R: add test
 
 2017-08-26  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-06-07  Kevin Ushey  <kevinushey@gmail.com>
+
+	* src/deoptim.cpp: disable RNG synchronization with dev. Rcpp
+
 2017-08-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* NAMESPACE: Use .registration=TRUE

--- a/src/deoptim.cpp
+++ b/src/deoptim.cpp
@@ -28,6 +28,10 @@ Rcpp::List DEoptim_impl(const arma::colvec & minbound,                  // user-
                         const Rcpp::List & control,                     // parameters 
                         SEXP rhoS) {                                    // optional environment
     
+#if RCPP_DEV_VERSION >= RcppDevVersion(0,12,17,1)
+    Rcpp::SuspendRNGSynchronizationScope rngScope;
+#endif
+
     double VTR           = Rcpp::as<double>(control["VTR"]);            // value to reach
     int i_strategy       = Rcpp::as<int>(control["strategy"]);          // chooses DE-strategy
     int i_itermax        = Rcpp::as<int>(control["itermax"]);           // Maximum number of generations

--- a/tests/rosenbrock.R
+++ b/tests/rosenbrock.R
@@ -1,0 +1,27 @@
+library(Rcpp)
+library(RcppDE)
+
+set.seed(1234)
+
+nothing <- function() {}
+sourceCpp(code = '
+#include <Rcpp.h>
+          
+// [[Rcpp::export]]
+void nothing() {}
+')
+
+Rosenbrock <- function(x) {
+  nothing()
+  x1 <- x[1]
+  x2 <- x[2]
+  100 * (x2 - x1 * x1) ^ 2 + (1 - x1) ^ 2
+}
+
+lower <- c(-10, -10)
+upper <- -lower
+cont <- DEoptim.control(trace = 0)
+
+fit <- DEoptim(Rosenbrock, lower, upper, control = cont)
+
+stopifnot(all.equal(fit$optim$bestmem, c(par1 = 1, par2 = 1)))

--- a/tests/rosenbrock.R
+++ b/tests/rosenbrock.R
@@ -3,16 +3,12 @@ library(RcppDE)
 
 set.seed(1234)
 
-nothing <- function() {}
-sourceCpp(code = '
-#include <Rcpp.h>
-          
-// [[Rcpp::export]]
-void nothing() {}
-')
-
 Rosenbrock <- function(x) {
-  nothing()
+  
+  # briefly, calls to functions generated with Rcpp Attributes
+  # could break optimizers due to incorrect sync of RNG state
+  RcppDE:::putFunPtrInXPtr("dummy")
+  
   x1 <- x[1]
   x2 <- x[2]
   100 * (x2 - x1 * x1) ^ 2 + (1 - x1) ^ 2

--- a/tests/rosenbrock.R
+++ b/tests/rosenbrock.R
@@ -20,4 +20,5 @@ cont <- DEoptim.control(trace = 0)
 
 fit <- DEoptim(Rosenbrock, lower, upper, control = cont)
 
-stopifnot(all.equal(fit$optim$bestmem, c(par1 = 1, par2 = 1)))
+if (packageVersion("Rcpp") >= "0.12.17.1")
+  stopifnot(all.equal(fit$optim$bestmem, c(par1 = 1, par2 = 1)))


### PR DESCRIPTION
This PR fixes the issue noted in #14 where attempts to call functions generated with Rcpp Attributes could break optimizers.